### PR TITLE
[BUGFIX] - Prevent error/warning from discord.py

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -191,6 +191,7 @@ def get_last_update_times():
 
 # Set up Discord bot with default intents
 intents = discord.Intents.default()
+intents.message_content = True  # Enable the message content intent
 bot = commands.Bot(command_prefix="!", intents=intents)
 
 # Event handler for when the bot is ready


### PR DESCRIPTION
Prevent error
discord.ext.commands.bot Privileged message content intent is missing, commands may not work as expected.